### PR TITLE
Update cf-pages-slack-notification to v3 / use Tokens

### DIFF
--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -7,10 +7,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Send Slack deployment notifications
-      uses: arddluma/cloudflare-pages-slack-notification@v2.5
+      uses: arddluma/cloudflare-pages-slack-notification@v3
       with:
-        accountEmail: ${{ secrets.CF_ACCOUNT_EMAIL  }}
-        apiKey: ${{ secrets.CF_API_KEY  }}
+        apiToken: ${{ secrets.CF_API_TOKEN }}
         accountId: ${{ secrets.CF_ACC_ID  }}
         project: ${{ secrets.CF_PROJECT  }}
         githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update gh action to  arddluma/cloudflare-pages-slack-notification@v3 to use token instead of API key